### PR TITLE
CayenneArduinoMQTTClient::loop not blocking for 1 second anymore

### DIFF
--- a/src/CayenneArduinoMQTTClient.h
+++ b/src/CayenneArduinoMQTTClient.h
@@ -87,7 +87,7 @@ public:
 	void loop(unsigned long minCommunicationIntervalMs = 1000, int yieldTimeMs = 10) {
 		//because we don't want to fload the backend with to many messages we make sure they are at least x time appart
 		static unsigned long millisOfLastLoopCommunication = millis();
-		if (millis() - millisOfLastLoopCommunication > 1000) {
+		if (millis() - millisOfLastLoopCommunication < 1000) {
 			return;
 		}
 		millisOfLastLoopCommunication = millis();

--- a/src/CayenneArduinoMQTTClient.h
+++ b/src/CayenneArduinoMQTTClient.h
@@ -84,8 +84,15 @@ public:
 	/**
 	* Main Cayenne loop
 	*/
-	void loop() {
-		CayenneMQTTYield(&_mqttClient, 1000);
+	void loop(unsigned long minCommunicationIntervalMs = 1000, int yieldTimeMs = 10) {
+		//because we don't want to fload the backend with to many messages we make sure they are at least x time appart
+		static unsigned long millisOfLastLoopCommunication = millis();
+		if (millis() - millisOfLastLoopCommunication > 1000) {
+			return;
+		}
+		millisOfLastLoopCommunication = millis();
+		//go ahead with processing	
+		CayenneMQTTYield(&_mqttClient, yieldTimeMs);
 		pollChannels(virtualChannels);
 #ifdef DIGITAL_AND_ANALOG_SUPPORT
 		pollChannels(digitalChannels);


### PR DESCRIPTION
CayenneArduinoMQTTClient::loop updated to not block for 1 second anymore, it now takes 2 optional parameters minCommunicationIntervalMs and yieldTimeMs to optimise performance of the main loop function. Note that this is potentially a breaking change IF you are counting on the 1 second delay for other stuff in your loop function. But this is then easily fixed by adding the delay(1000) yourself in the loop function.